### PR TITLE
Optimize PluginRoutes methods

### DIFF
--- a/lib/plugin_routes.rb
+++ b/lib/plugin_routes.rb
@@ -3,23 +3,16 @@
 class PluginRoutes
   # draw "all" gems registered for the plugins or themes and camaleon gems
   def self.draw_gems
-    res = []
-    dirs = [] + Dir["#{apps_dir}/plugins/*"] + Dir["#{apps_dir}/themes/*"]
+    gemfiles = Dir["#{apps_dir}/{plugins,themes}/*/config/Gemfile"]
 
-    dir_entries = %w[. ..]
-    dirs.each do |path|
-      next if dir_entries.include?(path)
-
-      g = File.join(path, 'config', 'Gemfile')
-      res << File.read(g) if File.exist?(g)
-    end
-    res.join("\n")
+    # map + read + join is very memory efficient for strings
+    # Ensuring a newline between files prevents syntax errors if a file lacks a trailing newline
+    gemfiles.map { |gem| File.read(gem, encoding: 'UTF-8') }.join("\n\n")
   end
 
-  # return apps directory path
+  # Returns the app's directory path
+  # It is also defined in the Camaleon CMS gem, but it is used when loading gems, so camaleon_cms isn't yet loaded here
   def self.apps_dir
-    dir = File.dirname(__FILE__).to_s.split('/')
-    dir.pop
-    "#{dir.join('/')}/app/apps"
+    File.join(File.dirname(__dir__), 'app', 'apps')
   end
 end


### PR DESCRIPTION
#### Changes:
- **Skip File.exist?**: Just call `File.read`. In Ruby, it is often faster to attempt the read and rescue the error (or use a glob that guarantees existence) than to check existence first and then read.
- **Target the Gemfiles directly**: Instead of getting all directory paths and then appending `/config/Gemfile`, let the `Dir[]` glob find the Gemfiles. This eliminates the `each` loop logic and the `File.join` overhead.
- **Guard against missing trailing newlines**: If a plugin author forgets to put a newline at the end of their Gemfile, joining them might result in a syntax error (e.g., the last line of one file and the first line of the next merging together).
- **Enforce file reading in UTF-8**: Since Gemfiles are technically Ruby code, they are usually UTF-8. To be extremely safe and prevent "invalid byte sequence" errors in rare environments, let's can force the encoding: `File.read(gem, encoding: 'UTF-8')`